### PR TITLE
feat: Make youtube tags comma-separated on PR

### DIFF
--- a/functions/pull-request/pr-description.ts
+++ b/functions/pull-request/pr-description.ts
@@ -37,6 +37,6 @@ ${summary.episodeSummary}
 ${ytChapters}
 
 ## Suggested Tags
-${summary.tags.join('\n')}
+${summary.tags.join(', ')}
 `
 }

--- a/tests/functions/pull-request/pr-description.test.ts
+++ b/tests/functions/pull-request/pr-description.test.ts
@@ -63,9 +63,6 @@ We hallucinate about topics we don't understand
 49:59 Conclusion and desperate appeal for more subscribers
 
 ## Suggested Tags
-InfiniDash
-SpodlgeWrangler
-CloudFormation
-Cost Explorer
+InfiniDash, SpodlgeWrangler, CloudFormation, Cost Explorer
 `)
 })


### PR DESCRIPTION
To make tags easier to copy-paste into the YouTube UI, it's better to have them comma-separated:

![Kapture 2023-11-08 at 14 51 26](https://github.com/fourTheorem/episoder/assets/205629/1a0d7b7f-6583-4aba-894a-c7ed866f2544)
